### PR TITLE
Exclude test files from source files

### DIFF
--- a/definitions/020-devenv-defs.mk
+++ b/definitions/020-devenv-defs.mk
@@ -11,6 +11,9 @@ PROJECT_DEVENV_SETTINGS := $(PROJECT_ROOT)/$(DEVENV)
 # Source folder
 SRC_FOLDER ?= $(PROJECT_ROOT)/src
 
+# Assume tests are located in "src/tests" folder by default
+TEST_FOLDER ?= $(SRC_FOLDER)/tests
+
 # Output folder
 OUTPUT_ROOT ?= $(PROJECT_ROOT)/out
 

--- a/definitions/030-python-defs.mk
+++ b/definitions/030-python-defs.mk
@@ -16,7 +16,7 @@ ifdef PROJECT_ROOT
 PYTHON_PROJECT_SETTINGS := $(PROJECT_ROOT)/$(PYTHON_SETTINGS)
 
 # Python source files
-PYTHON_SRC_FILES := $(shell find $(SRC_FOLDER) -name '*.py' 2>/dev/null)
+PYTHON_SRC_FILES := $(shell find $(SRC_FOLDER) -name '*.py' ! -path "$(TEST_FOLDER)/*" 2>/dev/null)
 
 # Is Python project?
 ifneq ($(PYTHON_SRC_FILES),)

--- a/definitions/070-tests-defs.mk
+++ b/definitions/070-tests-defs.mk
@@ -3,10 +3,6 @@
 # Python project?
 ifdef IS_PYTHON_PROJECT
 
-# Assume tests are localted in "tests" folder by default
-# (can be overriden)
-TEST_FOLDER ?= $(SRC_FOLDER)/tests/
-
 # All Python test files
 TEST_FILES := $(shell find $(TEST_FOLDER) -name '*.py' 2>/dev/null)
 


### PR DESCRIPTION
That improves incremental build behavior:
Python distribution is not rebuilt if only tests were updated