### PR TITLE
Handle Python workspace dependencies

### DIFF
--- a/definitions/005-helpers.mk
+++ b/definitions/005-helpers.mk
@@ -1,9 +1,6 @@
 # Helpers location
 HELPERS_ROOT := $(DEVENV_ROOT)/helpers
 
-# Helper for repo metadata
-REPO_HELPER := $(HELPERS_ROOT)/repo.py
-
 # Helper for status display
 STATUS_HELPER := $(HELPERS_ROOT)/status.py
 

--- a/definitions/010-repo-defs.mk
+++ b/definitions/010-repo-defs.mk
@@ -10,14 +10,17 @@ CACHE_SHARED_DIR := $(shell mkdir -p $(REPO_ROOT)/.cache && echo $(REPO_ROOT)/.c
 # Cache for original manifest name
 ORIGINAL_MANIFEST := $(CACHE_SHARED_DIR)/original.manifest
 
+# Helper for repo metadata
+REPO_HELPER := $(HELPERS_ROOT)/repo.py -r $(REPO_ROOT)
+
 # Repo metadata
-REPO_URL := $(shell $(REPO_HELPER) -r $(REPO_ROOT) --url)
-REPO_GROUPS := $(shell $(REPO_HELPER) -r $(REPO_ROOT) --groups)
-REPO_CHECKOUT_CMD := $(REPO_HELPER) -r $(REPO_ROOT) --checkout
+REPO_URL := $(shell $(REPO_HELPER) --url)
+REPO_GROUPS := $(shell $(REPO_HELPER) --groups)
+REPO_CHECKOUT_CMD := $(REPO_HELPER) --checkout
 ifdef MANIFEST_RESET
 REPO_MANIFEST := $(shell if test -e $(ORIGINAL_MANIFEST); then cat $(ORIGINAL_MANIFEST); else echo "manifest.xml"; fi)
 else
-REPO_MANIFEST := $(shell $(REPO_HELPER) -r $(REPO_ROOT) --manifest)
+REPO_MANIFEST := $(shell $(REPO_HELPER) --manifest)
 endif
 
 # All in one setup rules
@@ -46,7 +49,7 @@ ifdef BRANCH_MANIFEST_OPTIONS
 ORIGINAL_MANIFEST_STATUS := $(shell if test ! -e $(ORIGINAL_MANIFEST); then echo $(REPO_MANIFEST) > $(ORIGINAL_MANIFEST); fi)
 
 # Generate branch manifest
-BRANCH_MANIFEST_BUILD = $(FILE_STATUS) -s "Generating branch manifest" -- $(REPO_HELPER) -r $(REPO_ROOT) -b $(BRANCH_MANIFEST_OPTIONS)
+BRANCH_MANIFEST_BUILD = $(FILE_STATUS) -s "Generating branch manifest" -- $(REPO_HELPER) -b $(BRANCH_MANIFEST_OPTIONS)
 SYNC_OPTIONS := --no-manifest-update
 
 else # !BRANCH_MANIFEST_OPTIONS
@@ -58,7 +61,7 @@ endif # !BRANCH_MANIFEST_OPTIONS
 ifdef PROJECT_ROOT
 
 # Set project name
-PROJECT_NAME := $(shell $(REPO_HELPER) -r $(REPO_ROOT) --name)
+PROJECT_NAME := $(shell $(REPO_HELPER) --name)
 
 # Project cache
 CACHE_DIR := $(shell mkdir -p $(CACHE_SHARED_DIR)/$(PROJECT_NAME) && echo $(CACHE_SHARED_DIR)/$(PROJECT_NAME))

--- a/definitions/020-devenv-defs.mk
+++ b/definitions/020-devenv-defs.mk
@@ -34,10 +34,13 @@ endif # PROJECT_ROOT
 
 # Shared workspace settings
 ifdef WORKSPACE_PROJECT_ROOT
+ifneq ($(wildcard $(WORKSPACE_PROJECT_ROOT)/deps.json),)
 
 # Map of inter-project dependencies within the workspace
-ifneq ($(wildcard $(WORKSPACE_PROJECT_ROOT)/deps.json),)
 WORKSPACE_DEPS_MAP := $(WORKSPACE_PROJECT_ROOT)/deps.json
-endif
 
+# List of current project dependencies paths
+PROJECT_DEPS_PATHS := $(shell $(REPO_HELPER) -p @deps --dependencies $(WORKSPACE_DEPS_MAP))
+
+endif # WORKSPACE_DEPS_MAP
 endif # WORKSPACE_PROJECT_ROOT

--- a/definitions/040-venv-defs.mk
+++ b/definitions/040-venv-defs.mk
@@ -21,4 +21,22 @@ ifdef PYTHON_DISTRIBUTION
 PYTHON_DISTRIBUTION_INSTALL := $(PYTHON_VENV)/lib/$(PYTHON_FOR_VENV)/site-packages/$(shell echo $(PYTHON_PACKAGE) | sed -e 's/-/_/g')-$(VERSION).egg-info
 endif
 
+ifdef SUB_MAKE
+# Triggered at workspace level, don't check system dependencies (already done)
+PYTHON_VENV_DEPS := $(PYTHON_VENV_REQUIREMENTS)
+else
+# Triggered at project level, check system dependencies
+PYTHON_VENV_DEPS := $(PYTHON_VENV_REQUIREMENTS) $(SYSDEPS_TIME)
+endif
+
+ifdef WORKSPACE_DEPS_MAP
+ifndef SUB_MAKE
+
+# Add project dependencies distributions to venv dependencies
+PYTHON_VENV_WORKSPACE_REQUIREMENTS := $(shell $(HELPERS_ROOT)/list-deps-dists.sh $(foreach P,$(PROJECT_DEPS_PATHS),$(WORKSPACE_ROOT)/$(P)))
+PYTHON_VENV_DEPS += $(PYTHON_VENV_WORKSPACE_REQUIREMENTS)
+
+endif # !SUB_MAKE
+endif # WORKSPACE_DEPS_MAP
+
 endif # IS_PYTHON_PROJECT

--- a/rules/040-venv-rules.mk
+++ b/rules/040-venv-rules.mk
@@ -6,14 +6,6 @@
 # Only if current project is a Python one
 ifdef IS_PYTHON_PROJECT
 
-ifdef SUB_MAKE
-# Triggered at workspace level, don't check system dependencies (already done)
-PYTHON_VENV_DEPS := $(PYTHON_VENV_REQUIREMENTS)
-else
-# Triggered at project level, check system dependencies
-PYTHON_VENV_DEPS := $(PYTHON_VENV_REQUIREMENTS) $(SYSDEPS_TIME)
-endif
-
 # CI: currently building *this* project?
 ifdef CI
 ifeq ($(CI_PROJECT),$(PROJECT_NAME))
@@ -28,7 +20,11 @@ ifdef BUILD_VENV
 # Virtual env for current project
 # Handle clean of venv folder if something went wrong...
 $(PYTHON_VENV): $(PYTHON_VENV_DEPS)
-	$(GIFT_STATUS) --lang python -s "Create Python virtual environment" -- $(HELPERS_ROOT)/setup-venv.sh $(PYTHON_FOR_VENV) $(PYTHON_VENV) $(PYTHON_VENV_REQUIREMENTS)
+	$(GIFT_STATUS) --lang python -s "Update Python virtual environment" -- $(HELPERS_ROOT)/setup-venv.sh \
+		$(PYTHON_FOR_VENV) \
+		$(PYTHON_VENV) \
+		$(PYTHON_VENV_REQUIREMENTS) \
+		$(PYTHON_VENV_WORKSPACE_REQUIREMENTS)
 
 # Clean virtual env
 clean-venv:
@@ -49,10 +45,10 @@ ifndef PROJECT_ROOT
 
 ifdef CI
 CLEAN_VENV_STATUS := "Clean Python virtual environment for CI built project ($(CI_PROJECT))"
-BUILD_VENV_STATUS := "Create Python virtual environment for CI built project ($(CI_PROJECT))"
+BUILD_VENV_STATUS := "Update Python virtual environment for CI built project ($(CI_PROJECT))"
 else  # !CI
 CLEAN_VENV_STATUS := "Clean all Python virtual environments"
-BUILD_VENV_STATUS := "Create all Python virtual environments"
+BUILD_VENV_STATUS := "Update all Python virtual environments"
 endif # !CI
 
 # At workspace root, trigger venv build for all projects

--- a/rules/120-release-rules.mk
+++ b/rules/120-release-rules.mk
@@ -6,7 +6,7 @@ ifdef WORKSPACE_DEPS_MAP
 # Release target for current project
 .PHONY: release
 release:
-	$(FILE_STATUS) -s "Generate release manifest" -- $(REPO_HELPER) -r $(REPO_ROOT) --release --dependencies $(WORKSPACE_DEPS_MAP)
+	$(FILE_STATUS) -s "Generate release manifest" -- $(REPO_HELPER) --release --dependencies $(WORKSPACE_DEPS_MAP)
 
 endif # WORKSPACE_DEPS_MAP
 endif # PROJECT_ROOT

--- a/src/helpers/common.py
+++ b/src/helpers/common.py
@@ -1,7 +1,6 @@
 """
 Some shared functions for helpers
 """
-import json
 import subprocess
 import time
 from enum import Enum
@@ -180,18 +179,3 @@ def capture_cmd(args, cmd, stamp=None) -> int:
 
     # In all cases, return sub-process rc
     return rc
-
-
-# Reads dependencies list for a given project
-def read_dependencies(deps: Path, name: str) -> list:
-    # Load dependencies map from file
-    with deps.open("r") as f:
-        deps_map = json.load(f)
-
-    # Return the one for current project + all shared ones
-    out = set()
-    for item in ["_shared", name]:
-        if item in deps_map:
-            for item_dep in deps_map[item]:
-                out.add(item_dep)
-    return out

--- a/src/helpers/list-deps-dists.sh
+++ b/src/helpers/list-deps-dists.sh
@@ -1,0 +1,12 @@
+#!/bin/bash
+
+# Invoked with list of dependencies
+for DEP in "$@"; do
+    # Get Python dependency
+    DEP_DIST="$(SUB_MAKE=1 DISPLAY_MAKEFILE_VAR=PYTHON_DISTRIBUTION make -C ${DEP} display | grep -vE '^make')"
+
+    # Add to list only if path exists
+    if test -n "${DEP_DIST}" -a -e "${DEP_DIST}"; then
+        echo "${DEP_DIST}"
+    fi
+done

--- a/src/helpers/setup-venv.sh
+++ b/src/helpers/setup-venv.sh
@@ -9,8 +9,16 @@ shift
 PYTHON_VENV="$1"
 shift
 
-# Remaining args are requirement files
-DEPFILES="$@"
+# Remaining args are either requirement files (.txt) or archive files coming from dependencies
+REQS_LIST=""
+DIST_LIST=""
+for CANDIDATE in "$@"; do
+    if test "$(basename ${CANDIDATE})" !=  "$(basename -s txt ${CANDIDATE})"; then
+        REQS_LIST="${REQS_LIST} ${CANDIDATE}"
+    else
+        DIST_LIST="${DIST_LIST} ${CANDIDATE}"
+    fi
+done
 
 # Prepare venv
 RC=0
@@ -21,9 +29,18 @@ if test "$RC" -ne 0; then
     exit $RC;
 fi
 
+# Install dependencies first, if any, and if file exist
+PIP_CMD="pip install --upgrade --force-reinstall"
+if test -n "${DIST_LIST}"; then
+    for DIST in $DIST_LIST; do
+        PIP_CMD="$PIP_CMD ${DIST}"
+    done
+    (source $PYTHON_VENV/bin/activate && $PIP_CMD)
+fi
+
 # Finaly finish setup by doing pip installs
-PIP_CMD="pip install "
-for DEPFILE in $DEPFILES; do
+PIP_CMD="pip install"
+for DEPFILE in $REQS_LIST; do
     PIP_CMD="$PIP_CMD -r $DEPFILE"
 done
 (source $PYTHON_VENV/bin/activate && $PIP_CMD)

--- a/src/tests/test_repo.py
+++ b/src/tests/test_repo.py
@@ -3,10 +3,10 @@ import logging
 import os
 import shutil
 import subprocess
+from argparse import Namespace
 
 import pytest
 
-from helpers.common import read_dependencies
 from helpers.repo import RepoHandler, main
 from tests.test_shared import TestHelpers
 
@@ -194,13 +194,20 @@ class TestRepoHelperMisc(TestRepoHelper):
         # Verify path from name
         assert self.call_repo(["-p", "sample_dep"]) == "core/other"
 
-    def test_dependencies(self):
+    def test_deps_path(self, cd_project_api):
+        # Verify dependencies paths
+        workspace = self.repo.parent.resolve() / ".workspace"
+        assert self.call_repo(["-p", "@deps", "-d", str(workspace / "deps.json")]) == "core/other\ntools"
+
+    def test_dependencies(self, repo_copy):
         # Just test dependencies loading mechanisms
-        deps = read_dependencies(self.resources_folder / "workspace" / "deps.json", "api")
+        r = RepoHandler(self.repo)
+        args = Namespace(**{"dependencies": self.resources_folder / "workspace" / "deps.json"})
+        deps = r.read_dependencies(args, "api")
         assert len(deps) == 2
         assert "tools" in deps
         assert "sample_dep" in deps
-        deps = read_dependencies(self.resources_folder / "workspace" / "deps.json", "other")
+        deps = r.read_dependencies(args, "other")
         assert len(deps) == 1
         assert "tools" in deps
 


### PR DESCRIPTION
* add capability in repo helper to display all dependencies paths
* make venv depends on workspace built and existing dependencies
* build venv with workspace dependencies first (with forced install/upgrade)