### PR TITLE
Remove support for PYTHON_INTERNAL_REPOSITORY_URL

### DIFF
--- a/.devenv/python/shared/requirements-dev.txt
+++ b/.devenv/python/shared/requirements-dev.txt
@@ -2,7 +2,7 @@
 black
 
 ## Flake8 & plugins
-flake8
+flake8<3.8.0
 flake8-html
 pep8-naming
 flake8-builtins

--- a/definitions/040-venv-defs.mk
+++ b/definitions/040-venv-defs.mk
@@ -34,7 +34,7 @@ ifndef SUB_MAKE
 
 # Add project dependencies distributions to venv dependencies
 PYTHON_VENV_WORKSPACE_REQUIREMENTS := $(shell $(HELPERS_ROOT)/list-deps-dists.sh $(foreach P,$(PROJECT_DEPS_PATHS),$(WORKSPACE_ROOT)/$(P)))
-PYTHON_VENV_DEPS += $(shell echo "$(PYTHON_VENV_WORKSPACE_REQUIREMENTS)" | grep -vE '^http://')
+PYTHON_VENV_DEPS += $(PYTHON_VENV_WORKSPACE_REQUIREMENTS)
 
 endif # !SUB_MAKE
 endif # WORKSPACE_DEPS_MAP

--- a/src/helpers/list-deps-dists.sh
+++ b/src/helpers/list-deps-dists.sh
@@ -7,15 +7,9 @@ for DEP in "$@"; do
         # Get Python dependency
         DEP_DIST="$(SUB_MAKE=1 DISPLAY_MAKEFILE_VAR=PYTHON_DISTRIBUTION make -C ${DEP} display | grep -vE '^make')"
 
-        # Add to list only if there is a distribution
-        if test -n "${DEP_DIST}"; then
-            # Built locally?
-            if test -e "${DEP_DIST}"; then
-                echo "${DEP_DIST}"
-            elif test -n "${PYTHON_INTERNAL_REPOSITORY_URL}"; then
-                # Will install from internal repository (with provided URL)
-                echo "${PYTHON_INTERNAL_REPOSITORY_URL}/$(basename ${DEP_DIST})"
-            fi
+        # Add to list only if there is a built distribution
+        if test -n "${DEP_DIST}" -a -e "${DEP_DIST}"; then
+            echo "${DEP_DIST}"
         fi
     fi
 done

--- a/src/tests/test_deps_dists.py
+++ b/src/tests/test_deps_dists.py
@@ -33,9 +33,3 @@ class TestDepsDistsHelper(TestHelpers):
         os.environ["OUTPUT_ROOT"] = (self.test_project / "out").as_posix()
         assert self.call_helper() == artifact.resolve().as_posix()
         del os.environ["OUTPUT_ROOT"]
-
-    def test_repo(self):
-        # Local dep not built, but internal repo provided
-        os.environ["PYTHON_INTERNAL_REPOSITORY_URL"] = "http://foo.org/artifacts"
-        assert self.call_helper() == "http://foo.org/artifacts/foo-stuff-1.2.3.tar.gz"
-        del os.environ["PYTHON_INTERNAL_REPOSITORY_URL"]


### PR DESCRIPTION
Finally, remove useless support for http install.
Support for internal pip repo should be enough.