### PR TITLE
Handle release manifest build with existing tags

### DIFF
--- a/src/tests/resources/repo/default/manifests/manifest.xml
+++ b/src/tests/resources/repo/default/manifests/manifest.xml
@@ -4,7 +4,7 @@
     <default remote="some-github" revision="refs/heads/master"/>
 
     <!-- Tools -->
-    <project path="tools" name="tools" dest-branch="master" groups="tools">
+    <project path="tools" name="tools" dest-branch="master" revision="refs/heads/master" groups="tools">
         <linkfile src="Makefile" dest="Makefile"/>
     </project>
 
@@ -13,7 +13,7 @@
 
     <!-- Core -->
     <project path="core/api" name="api" dest-branch="master" groups="notdefault,core"/>
-    <project path="core/other" name="sample_dep" dest-branch="master" groups="notdefault,core"/>
+    <project path="core/other" name="sample_dep" dest-branch="9.9.9" revision="refs/tags/9.9.9" groups="notdefault,core"/>
 
     <project path="something" name="another_project" dest-branch="master" groups="notdefault,core"/>
 </manifest>

--- a/src/tests/test_repo.py
+++ b/src/tests/test_repo.py
@@ -115,9 +115,13 @@ class TestRepoHelperMisc(TestRepoHelper):
                 assert p.attributes["dest-branch"].value == "2.3"
                 assert p.attributes["revision"].value == "refs/tags/2.3"
                 tested_projects += 1
-            elif r.project_name(p) in ["tools", "sample_dep"]:
+            elif r.project_name(p) in ["tools"]:
                 assert p.attributes["dest-branch"].value == "6.7"
                 assert p.attributes["revision"].value == "refs/tags/6.7"
+                tested_projects += 1
+            elif r.project_name(p) in ["sample_dep"]:
+                assert p.attributes["dest-branch"].value == "9.9.9"
+                assert p.attributes["revision"].value == "refs/tags/9.9.9"
                 tested_projects += 1
         assert tested_projects == 4
         assert total_projects == 4


### PR DESCRIPTION
When building a release manifest:
* systematically consider both workspace and devenv as dependencies
* don't touch existing tags in the manifest, if any