### PR TITLE
#50: Don't build venv at workspace root out of CI

### DIFF
--- a/definitions/015-ci-defs.mk
+++ b/definitions/015-ci-defs.mk
@@ -1,0 +1,11 @@
+# Some definitions for CI
+ifdef CI
+ifdef CI_PROJECT
+ifndef PROJECT_ROOT
+
+# At workspace root, reckon CI project path
+CI_PROJECT_ROOT := $(shell $(REPO_HELPER) --path $(CI_PROJECT))
+
+endif # PROJECT_ROOT
+endif # CI_PROJECT
+endif # CI


### PR DESCRIPTION
* If out of CI, don't build venv from workspace root anymore
* In CI, build only the current CI_PROJECT one